### PR TITLE
Site-wide sigil fix + Demon Codex anime.js v4 pass

### DIFF
--- a/demon-codex.html
+++ b/demon-codex.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="The Demon Codex: seven laws of volatility harvesting from the Demon Ranch research campaign — Shannon's Demon on a small, diversified, human-run book. Simulated research, not investment advice." />
   <title>thisisez.com — The Demon Codex | Volatility-Harvesting Doctrine</title>
   <style>
     :root { color-scheme: dark; --bg:#070a12; --panel:#101827; --panel2:#162033; --text:#e5edf8; --muted:#94a3b8; --line:#263244; --good:#6ee7a8; --bad:#fb7185; --warn:#fbbf24; --blue:#7dd3fc; --violet:#c4b5fd; }
@@ -45,16 +46,18 @@
     .badge.wip { color:var(--warn); border:1px solid rgba(251,191,36,.55); background:rgba(251,191,36,.11); }
     .status-key { margin-top:14px; max-width:1120px; border:1px dashed var(--line); border-radius:14px; padding:10px 14px; font-size:12.5px; color:var(--muted); line-height:1.6; }
     .status-key b { color:#e5edf8; }
+    .sigil { height:.82em; width:.82em; vertical-align:-.06em; }
+    h1 .sigil { height:.8em; width:.8em; vertical-align:-.04em; filter: drop-shadow(0 0 10px rgba(196,181,253,.55)); }
     @media (max-width: 900px) { main { padding-inline: 10px; } }
   </style>
 </head>
 <body>
 <header>
   <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:14px; flex-wrap:wrap;">
-    <h1><span class="glyph">𖤐</span> The Demon Codex</h1>
+    <h1><span class="glyph"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><defs><linearGradient id="sg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#c4b5fd"/><stop offset="1" stop-color="#7dd3fc"/></linearGradient></defs><circle cx="50" cy="50" r="44" fill="none" stroke="url(#sg)" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="url(#sg)" stroke-width="6.5"/></svg></span> The Demon Codex</h1>
     <div style="display:flex; gap:8px; flex-wrap:wrap;">
-      <a class="nav" href="demon-ladder.html">𖤐 the Demon Ladder</a>
-      <a class="nav" href="first-order-demons.html">𖤐 First-Order Explorer</a>
+      <a class="nav" href="demon-ladder.html"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="6.5"/></svg> the Demon Ladder</a>
+      <a class="nav" href="first-order-demons.html"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="6.5"/></svg> First-Order Explorer</a>
       <a class="nav" href="index.html">← back to thisisez.com</a>
     </div>
   </div>
@@ -73,11 +76,10 @@
   </div>
   <div class="callout">Excess growth rate of a pair ≈ <b>½ · var(return spread) · 252</b> = annualized pairwise demon yield. This one scalar is the heat map the whole apparatus is built around.</div>
 
-  <div class="section-label">The stakes gradient — three markets, one curriculum</div>
+  <div class="section-label">The stakes gradient — two labs, one curriculum</div>
   <div class="cards">
     <div class="card"><div class="k">Tier 1 · zero stakes</div><div class="v">Demon Ranch</div><div class="ex">Backtest sim. Where the math is derived and stress-tested.</div></div>
-    <div class="card"><div class="k">Tier 2 · live, fake money</div><div class="v">Doomhowl (WoW HC)</div><div class="ex">A real auction house with human opponents. Where strategy meets counterparties no backtest can simulate.</div></div>
-    <div class="card"><div class="k">Tier 3 · real dollars</div><div class="v">Robinhood Lab</div><div class="ex">Small agentic cash account. Where doctrine gets blood.</div></div>
+    <div class="card"><div class="k">Tier 2 · real dollars</div><div class="v">Robinhood Lab</div><div class="ex">Small agentic cash account. Where doctrine gets blood.</div></div>
   </div>
   <div class="explainer">Findings promote upward only. Same verification epistemics — ledger over theory, parity gates, catch each other's errors — run identically at every tier. <b>This, not any single lab, is the apparatus.</b></div>
 
@@ -161,10 +163,10 @@
 
   <div class="section-label">Findings to date · Lab 7-sleeve, $1,000, adjusted-close proxy</div>
   <div class="stat">
-    <div class="card"><div class="k">Full cycle reverses the verdict</div><div class="v" style="color:var(--good)">~$4,600</div><div class="ex">harvesting vs <b>$2,717</b> buy-and-hold across 2020–2026 (with the 2022 bear)</div></div>
-    <div class="card"><div class="k">…at half the pain</div><div class="v" style="color:var(--good)">−37%</div><div class="ex">max drawdown vs <b>−69%</b> for buy-and-hold</div></div>
-    <div class="card"><div class="k">Harvest is insurance</div><div class="v">~62%</div><div class="ex">of 500 bootstrap worlds beaten — and 91% of the worlds where hold suffers most</div></div>
-    <div class="card"><div class="k">Human-runnable</div><div class="v">~12/yr</div><div class="ex">deliberate trades: coarse bites + dispersion drips + no gate. Runnable between massage clients.</div></div>
+    <div class="card"><div class="k">Full cycle reverses the verdict</div><div class="v" style="color:var(--good)" data-n="4600" data-pre="~$">~$4,600</div><div class="ex">harvesting vs <b>$2,717</b> buy-and-hold across 2020–2026 (with the 2022 bear)</div></div>
+    <div class="card"><div class="k">…at half the pain</div><div class="v" style="color:var(--good)" data-n="37" data-pre="−" data-suf="%">−37%</div><div class="ex">max drawdown vs <b>−69%</b> for buy-and-hold</div></div>
+    <div class="card"><div class="k">Harvest is insurance</div><div class="v" data-n="62" data-pre="~" data-suf="%">~62%</div><div class="ex">of 500 bootstrap worlds beaten — and 91% of the worlds where hold suffers most</div></div>
+    <div class="card"><div class="k">Human-runnable</div><div class="v" data-n="12" data-pre="~" data-suf="/yr">~12/yr</div><div class="ex">deliberate trades: coarse bites + dispersion drips + no gate. Runnable between massage clients.</div></div>
   </div>
 
   <div class="section-label">The tooling — what the research layer built <span class="badge live">Built &amp; tested</span></div>
@@ -191,5 +193,46 @@
     A Diamond Legendz / Demon Ranch research artifact, mirrored to thisisez.com. Simulated research, price/total-return proxy, partial costs, taxes and most frictions not modeled. Not investment advice. Selection bias included free.
   </div>
 </main>
+<script type="module">
+// anime.js v4 garnish, Fable-authored. The doctrine renders in full without it —
+// if the CDN is down or the reader prefers reduced motion, nothing below runs.
+try {
+  if (matchMedia('(prefers-reduced-motion: reduce)').matches) throw 0;
+  const { animate, stagger, onScroll, svg } = await import('https://cdn.jsdelivr.net/npm/animejs@4/+esm');
+
+  // Summon the sigil: stroke-draw the circle and the star, then let it turn forever.
+  animate(svg.createDrawable('h1 .sigil circle, h1 .sigil path'), {
+    draw: ['0 0', '0 1'], duration: 1800, delay: stagger(350), ease: 'inOut(3)',
+  });
+  animate('h1 .sigil', { rotate: 360, duration: 48000, ease: 'linear', loop: true });
+
+  // Card grids (laws, tiers, findings) rise in as each enters the viewport.
+  for (const grid of document.querySelectorAll('.cards, .stat')) {
+    animate(grid.querySelectorAll('.card'), {
+      opacity: [0, 1], translateY: [16, 0], delay: stagger(80), duration: 650, ease: 'out(3)',
+      autoplay: onScroll({ target: grid }),
+    });
+  }
+
+  // Table rows (the book, the twelve universes) sweep in row by row.
+  for (const wrap of document.querySelectorAll('.table-wrap')) {
+    animate(wrap.querySelectorAll('tbody tr'), {
+      opacity: [0, 1], translateX: [-14, 0], delay: stagger(55), duration: 500, ease: 'out(2)',
+      autoplay: onScroll({ target: wrap }),
+    });
+  }
+
+  // Headline findings count up from zero on first sight.
+  for (const el of document.querySelectorAll('.v[data-n]')) {
+    const end = +el.dataset.n, pre = el.dataset.pre || '', suf = el.dataset.suf || '';
+    const state = { n: 0 };
+    animate(state, {
+      n: end, duration: 1500, ease: 'out(4)',
+      onUpdate: () => { el.textContent = pre + Math.round(state.n).toLocaleString('en-US') + suf; },
+      autoplay: onScroll({ target: el }),
+    });
+  }
+} catch (e) { /* garnish only — never let motion break doctrine */ }
+</script>
 </body>
 </html>

--- a/demon-ladder.html
+++ b/demon-ladder.html
@@ -56,15 +56,17 @@
     .caveats { color:#cbd5e1; margin-top:14px; font-size:12.5px; line-height:1.55; max-width:1120px; }
     .caveats li { margin-bottom:5px; }
     .footer-note { color:var(--muted); margin-top: 16px; font-size:12px; }
+    .sigil { height:.82em; width:.82em; vertical-align:-.06em; }
+    h1 .sigil { height:.8em; width:.8em; vertical-align:-.04em; filter: drop-shadow(0 0 10px rgba(196,181,253,.55)); }
     @media (max-width: 900px) { main { padding-inline: 10px; } }
   </style>
 </head>
 <body>
 <header>
   <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:14px; flex-wrap:wrap;">
-    <h1><span class="glyph">𖤐</span> Demon Ladder</h1>
+    <h1><span class="glyph"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><defs><linearGradient id="sg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#c4b5fd"/><stop offset="1" stop-color="#7dd3fc"/></linearGradient></defs><circle cx="50" cy="50" r="44" fill="none" stroke="url(#sg)" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="url(#sg)" stroke-width="6.5"/></svg></span> Demon Ladder</h1>
     <div style="display:flex; gap:8px; flex-wrap:wrap;">
-      <a class="nav" href="first-order-demons.html">𖤐 First-Order Explorer →</a>
+      <a class="nav" href="first-order-demons.html"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="6.5"/></svg> First-Order Explorer →</a>
       <a class="nav" href="index.html">← back to thisisez.com</a>
     </div>
   </div>

--- a/first-order-demons.html
+++ b/first-order-demons.html
@@ -45,15 +45,17 @@
     .caveats { color:#cbd5e1; margin-top:10px; font-size:12.5px; line-height:1.55; max-width:1120px; }
     .caveats li { margin-bottom:5px; }
     .footer-note { color:var(--muted); margin-top: 18px; font-size:12px; max-width:1120px; line-height:1.5; }
+    .sigil { height:.82em; width:.82em; vertical-align:-.06em; }
+    h1 .sigil { height:.8em; width:.8em; vertical-align:-.04em; filter: drop-shadow(0 0 10px rgba(196,181,253,.55)); }
     @media (max-width: 900px) { main { padding-inline: 10px; } }
   </style>
 </head>
 <body>
 <header>
   <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:14px; flex-wrap:wrap;">
-    <h1><span class="glyph">𖤐</span> First-Order Demon Explorer</h1>
+    <h1><span class="glyph"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><defs><linearGradient id="sg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#c4b5fd"/><stop offset="1" stop-color="#7dd3fc"/></linearGradient></defs><circle cx="50" cy="50" r="44" fill="none" stroke="url(#sg)" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="url(#sg)" stroke-width="6.5"/></svg></span> First-Order Demon Explorer</h1>
     <div style="display:flex; gap:8px; flex-wrap:wrap;">
-      <a class="nav" href="demon-ladder.html">𖤐 the Demon Ladder</a>
+      <a class="nav" href="demon-ladder.html"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="6.5"/></svg> the Demon Ladder</a>
       <a class="nav" href="index.html">← back to thisisez.com</a>
     </div>
   </div>
@@ -75,7 +77,7 @@
 
   <div class="section-label">② Spotlight — GLDM/TQQQ, the "gold multiplies TQQQ" story, stated precisely</div>
   <div class="explainer">Gold does pair beautifully with TQQQ in this window — but the best configuration is <b>90% TQQQ engine with GLDM as a 10% ballast</b>. Almost all the return is TQQQ itself; the "multiplication" is regime co-movement (gold and the Nasdaq both ripped), not rebalance alpha. Demon yield — annualized rebalance alpha vs the same-weight buy-and-hold — is <b>slightly negative</b> for every rebalanced GLDM/TQQQ row here (≈ −0.03% to −0.31%/yr). What rebalancing did buy: a shallower max drawdown (−53.5% vs −56.3%) and a slightly better Sharpe (1.37 vs 1.33).</div>
-  <div class="callout">𖤐 Verdict: gold acted as <b>ballast / stabilizer</b>, not as rebalance-alpha proof. Say "gold stabilized TQQQ here," not "gold multiplied TQQQ."</div>
+  <div class="callout"><svg class="sigil" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="6.5"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="6.5"/></svg> Verdict: gold acted as <b>ballast / stabilizer</b>, not as rebalance-alpha proof. Say "gold stabilized TQQQ here," not "gold multiplied TQQQ."</div>
   <div class="table-wrap"><table id="tbl-gold"><thead></thead><tbody></tbody></table></div>
 
   <div class="section-label">③ Top demon yield — the YANG/YINN fine print</div>

--- a/index.html
+++ b/index.html
@@ -33,19 +33,19 @@
             <div class="output">AVAILABLE ANALYSIS TOOLS:</div>
             <div class="output">═══════════════════════════════════════════════════════════════</div>
             <div class="output"><br></div>
-            <div class="output">𖤐 <a href="demon-codex.html" style="color: #fc0; font-weight: bold;">THE DEMON CODEX</a></div>
+            <div class="output"><a href="demon-codex.html" style="color: #fc0; font-weight: bold;"><svg style="height:.95em;width:.95em;vertical-align:-.12em" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="7"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="7"/></svg> THE DEMON CODEX</a></div>
             <div class="output"> The doctrine that generated the Ladder: seven laws of harvesting</div>
             <div class="output"> volatility from a small book, plus the Tournament of Power — 12</div>
             <div class="output"> universes of different market physics. Read this first.</div>
             <div class="output"> Status: LIVE | Type: Strategy doctrine. Still not advice.</div>
             <div class="output"><br></div>
-            <div class="output">𖤐 <a href="demon-ladder.html" style="color: #f55; font-weight: bold;">THE DEMON LADDER</a></div>
+            <div class="output"><a href="demon-ladder.html" style="color: #f55; font-weight: bold;"><svg style="height:.95em;width:.95em;vertical-align:-.12em" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="7"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="7"/></svg> THE DEMON LADDER</a></div>
             <div class="output"> Portfolio accretion research: bolt on one sleeve at a time and see</div>
             <div class="output"> which additions are engines, which are dead weight wearing a costume.</div>
             <div class="output"> Windows differ per row — sorted by CAGR so short windows can't lie to you.</div>
             <div class="output"> Status: LIVE | Type: Simulated backtests. Not advice. Obviously.</div>
             <div class="output"><br></div>
-            <div class="output">𖤐 <a href="first-order-demons.html" style="color: #c8f; font-weight: bold;">FIRST-ORDER DEMON EXPLORER</a></div>
+            <div class="output"><a href="first-order-demons.html" style="color: #c8f; font-weight: bold;"><svg style="height:.95em;width:.95em;vertical-align:-.12em" viewBox="0 0 100 100" aria-hidden="true"><circle cx="50" cy="50" r="44" fill="none" stroke="currentColor" stroke-width="7"/><path d="M50 91 25.9 16.8 89 62.7 11 62.7 74.1 16.8Z" fill="none" stroke="currentColor" stroke-width="7"/></svg> FIRST-ORDER DEMON EXPLORER</a></div>
             <div class="output"> Every two-sleeve pair, exhaustively: 190 pairs × 5 weights × 8 policies</div>
             <div class="output"> = 7,600 sims. Engine + ballast, gold vs TQQQ, one inverse-pair curiosity.</div>
             <div class="output"> Status: LIVE | Type: Simulated research. Selection bias included free.</div>


### PR DESCRIPTION
## What

- **Kills the tofu box.** The `𖤐` glyph (U+16920, Bamum Supplement) has zero coverage in stock Windows/iOS/Android fonts — it rendered as an empty box before the codex header and in every nav/index usage. Replaced site-wide (codex, ladder, first-order explorer, index) with an inline SVG demon sigil — inverted pentagram inscribed in a circle — that inherits the surrounding accent color via `currentColor`. The h1 versions get a violet→blue gradient stroke and a soft glow.
- **Doomhowl dropped from the codex stakes gradient.** Not the same demon — the connection was a stretch. Gradient is now two tiers: Demon Ranch (sim) → Robinhood Lab (real dollars).
- **anime.js v4 pass on the codex:** sigil stroke-draws itself on load then rotates once per 48s; law/tier/finding cards stagger-rise on scroll; table rows (the seven-sleeve book, the twelve universes) sweep in; the headline findings count up from zero on first sight. Loaded as an ES module from jsDelivr, wrapped in try/catch, `prefers-reduced-motion` respected — CDN failure or motion preference degrades to the exact static page.
- Codex gains a meta description.

## Verification

- Tag-balance parse across all four files: clean.
- `𖤐` / `Doomhowl` grep across repo: zero remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grd9drJpiq81Xm8GcHm1fU