### PR TITLE
Coin game: the owed-number theorem

### DIFF
--- a/demon-codex.html
+++ b/demon-codex.html
@@ -202,7 +202,7 @@
       <div class="gstat"><div class="k">The demon's edge</div><div class="v" id="cgedge">$0</div></div>
     </div>
     <svg id="cgchart" viewBox="0 0 1000 180" preserveAspectRatio="none" aria-label="Parked vs worked wealth over your flips"></svg>
-    <div class="cg-msg" id="cgmsg" aria-live="polite">flip the coin yourself — heads +5%, tails −4.76%; the worked book rebalances to 50/50 after every flip. Log-scale chart: grey = parked, violet = worked.</div>
+    <div class="cg-msg" id="cgmsg" aria-live="polite">flip the coin yourself — heads +5%, tails −4.76%; the worked book rebalances to 50/50 after every flip. Log-scale chart: grey = parked, violet = worked. (Why 50/50? For this coin it is a theorem, not a guess: a symmetric multiplicative coin owes the player exactly half — any other split lowers the median, though the hill is forgivingly flat from ~34% to ~66%. And under trading costs, rebalancing every flip pays a tax; a wide drift band recovers it in ~19 trades. Laws III and V hold even in the toy.)</div>
   </div>
   <div class="callout">The demon lives in the <b>spread between</b> assets, never in an asset. Excess growth rate of a pair ≈ <b>½ · var(return spread) · 252</b> — annualized pairwise demon yield; the doctrine calls this <b>γ (gamma)</b>. This one scalar is the heat map the whole apparatus is built around.</div>
 


### PR DESCRIPTION
The 50/50 is a theorem: w* = (u−d)/2ud = ½ exactly for symmetric multiplicative coins. Plateau 34–66%; under friction the band is earned (~10% drift, 19 trades). Sidecar: coin-kelly-20260712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grd9drJpiq81Xm8GcHm1fU